### PR TITLE
[teo.kkim 김태홍] WAS 미션 추가 PR입니다.

### DIFF
--- a/src/main/java/application/ListUserController.java
+++ b/src/main/java/application/ListUserController.java
@@ -21,18 +21,17 @@ public class ListUserController extends AbstractController {
     public static final String LOGIN_HTML = "login.html";
     public static final String LOGINED_TRUE = "logined=true";
     public static final String TEMPLATES = "/templates";
-    public static final String HTML = ".html";
 
     private final Logger logger = LoggerFactory.getLogger(ListUserController.class.getName());
 
-    boolean isLogin(String header) {
-        return header.equals(LOGINED_TRUE);
+    boolean isLogin(List<String> cookieValues) {
+        return cookieValues.contains(LOGINED_TRUE);
     }
 
     private byte[] compileHtmlBody(String url) throws IOException {
         TemplateLoader loader = new ClassPathTemplateLoader();
         loader.setPrefix(TEMPLATES);
-        loader.setSuffix(HTML);
+        loader.setSuffix("");
         Handlebars handlebars = new Handlebars(loader);
 
         Template template = handlebars.compile(url);

--- a/src/main/java/application/ListUserController.java
+++ b/src/main/java/application/ListUserController.java
@@ -8,6 +8,8 @@ import db.DataBase;
 import domain.HttpRequest;
 import domain.HttpResponse;
 import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -20,6 +22,8 @@ public class ListUserController extends AbstractController {
     public static final String LOGINED_TRUE = "logined=true";
     public static final String TEMPLATES = "/templates";
     public static final String HTML = ".html";
+
+    private final Logger logger = LoggerFactory.getLogger(ListUserController.class.getName());
 
     boolean isLogin(String header) {
         return header.equals(LOGINED_TRUE);
@@ -47,7 +51,7 @@ public class ListUserController extends AbstractController {
             byte[] body = compileHtmlBody(url);
             httpResponse.forward(url, body);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.info(e.getMessage());
         }
     }
 }

--- a/src/main/java/application/ListUserController.java
+++ b/src/main/java/application/ListUserController.java
@@ -19,13 +19,14 @@ public class ListUserController extends AbstractController {
 
     public static final String COOKIE = "Cookie";
     public static final String LOGIN_HTML = "login.html";
-    public static final String LOGINED_TRUE = "logined=true";
+    public static final String LOGINED_TRUE = "logined=true *";
     public static final String TEMPLATES = "/templates";
 
     private final Logger logger = LoggerFactory.getLogger(ListUserController.class.getName());
 
     boolean isLogin(List<String> cookieValues) {
-        return cookieValues.contains(LOGINED_TRUE);
+        return cookieValues.stream()
+                .anyMatch(value -> value.matches(LOGINED_TRUE));
     }
 
     private byte[] compileHtmlBody(String url) throws IOException {

--- a/src/main/java/application/LoginController.java
+++ b/src/main/java/application/LoginController.java
@@ -6,20 +6,33 @@ import domain.HttpResponse;
 import model.User;
 import service.MemberService;
 
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
 public class LoginController extends AbstractController {
 
     public static final String KEY_USER_ID = "userId";
     public static final String KEY_PASSWORD = "password";
     public static final String INDEX_HTML = "/index.html";
     public static final String KEY_SET_COOKIE = "Set-Cookie";
-    public static final String VALUE_LOGINED_TRUE = "logined=true; Path=/";
+    public static final String VALUE_LOGINED_TRUE = "logined=true; Path=/; expires=";
     public static final String LOGIN_FAILED_HTML = "/user/login_failed.html";
-    public static final String VALUE_LOGINED_FALSE = "logined=false;";
+    public static final int COOKIE_DURATION = 10;
 
     private final MemberService memberService;
 
     public LoginController(MemberService memberService) {
         this.memberService = memberService;
+    }
+
+    private String cookieWithExpireTime() {
+        OffsetDateTime offsetDateTime = OffsetDateTime
+                .now(ZoneOffset.UTC)
+                .plus(Duration.ofSeconds(COOKIE_DURATION));
+        String expiresTime = DateTimeFormatter.RFC_1123_DATE_TIME.format(offsetDateTime);
+        return VALUE_LOGINED_TRUE + expiresTime;
     }
 
     @Override
@@ -28,12 +41,11 @@ public class LoginController extends AbstractController {
             User user = DataBase.findUserById(httpRequest.getParameter(KEY_USER_ID));
             boolean isLoginSuccess = user.validatePassword(httpRequest.getParameter(KEY_PASSWORD));
             if (isLoginSuccess) {
-                httpResponse.addHeader(KEY_SET_COOKIE, VALUE_LOGINED_TRUE);
+                httpResponse.addHeader(KEY_SET_COOKIE, cookieWithExpireTime());
                 httpResponse.sendRedirect(INDEX_HTML);
                 return;
             }
         }
-        httpResponse.addHeader(KEY_SET_COOKIE, VALUE_LOGINED_FALSE);
         httpResponse.sendRedirect(LOGIN_FAILED_HTML);
     }
 }

--- a/src/main/java/domain/HttpHeaders.java
+++ b/src/main/java/domain/HttpHeaders.java
@@ -1,19 +1,19 @@
 package domain;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class HttpHeaders {
 
-    public static final String NO_KEY = "No Key";
+    private final Map<String, List<String>> headers;
 
-    private final Map<String, String> headers;
-
-    public HttpHeaders(Map<String, String> headers) {
+    public HttpHeaders(Map<String, List<String>> headers) {
         this.headers = headers;
     }
 
-    public String getHeader(String key) {
-        return headers.getOrDefault(key, NO_KEY);
+    public List<String> getHeader(String key) {
+        return headers.getOrDefault(key, Collections.emptyList());
     }
 
 }

--- a/src/main/java/domain/HttpRequest.java
+++ b/src/main/java/domain/HttpRequest.java
@@ -9,13 +9,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class HttpRequest {
 
     public static final String HEADER_DELIMITER = ": ";
     public static final String CONTENT_LENGTH = "Content-Length";
+    public static final String HEADER_VALUE_DELIMITER = "[;,]";
 
     private final HttpRequestStartLine httpRequestStartLine;
     private final HttpHeaders httpHeaders;
@@ -35,14 +35,14 @@ public class HttpRequest {
             params = KeyValueTokenizer.of(startLine.getParameter());
         }
 
-        Map<String, String> headers = new HashMap<>();
+        Map<String, List<String>> headers = new HashMap<>();
         String headerLine;
         while ((headerLine = br.readLine()) != null && !headerLine.isEmpty()) {
             addHeader(headers, headerLine);
         }
 
         if (headers.containsKey(CONTENT_LENGTH)) {
-            String content = IOUtils.readData(br, Integer.parseInt(headers.get(CONTENT_LENGTH)));
+            String content = IOUtils.readData(br, Integer.parseInt(headers.get(CONTENT_LENGTH).get(0)));
             params.putAll(KeyValueTokenizer.of(content));
         }
 
@@ -51,12 +51,16 @@ public class HttpRequest {
         return new HttpRequest(startLine, httpHeaders, httpParameters);
     }
 
-    private static void addHeader(Map<String, String> headers, String line) {
+    private static void addHeader(Map<String, List<String>> headers, String line) {
         String[] header = line.split(HEADER_DELIMITER);
-        headers.put(header[0], header[1]);
+        String key = header[0];
+        List<String> values = new ArrayList<>();
+        String[] headerValues = header[1].split(HEADER_VALUE_DELIMITER);
+        Collections.addAll(values, headerValues);
+        headers.put(key, values);
     }
 
-    public String getHeader(String key) {
+    public List<String> getHeader(String key) {
         return httpHeaders.getHeader(key);
     }
 

--- a/src/main/java/domain/HttpRequest.java
+++ b/src/main/java/domain/HttpRequest.java
@@ -42,7 +42,8 @@ public class HttpRequest {
         }
 
         if (headers.containsKey(CONTENT_LENGTH)) {
-            params.putAll(KeyValueTokenizer.of(IOUtils.readData(br, Integer.parseInt(headers.get(CONTENT_LENGTH)))));
+            String content = IOUtils.readData(br, Integer.parseInt(headers.get(CONTENT_LENGTH)));
+            params.putAll(KeyValueTokenizer.of(content));
         }
 
         HttpHeaders httpHeaders = new HttpHeaders(headers);

--- a/src/main/java/domain/HttpResponse.java
+++ b/src/main/java/domain/HttpResponse.java
@@ -90,7 +90,4 @@ public class HttpResponse {
         dos.writeBytes("\r\n");
     }
 
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
 }

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,7 +1,5 @@
 package model;
 
-import utils.KeyValueTokenizer;
-
 import java.util.Map;
 
 public class User {
@@ -17,16 +15,8 @@ public class User {
         this.email = email;
     }
 
-    public User(Map<String, String> parameters) {
-        this.userId = parameters.get("userId");
-        this.password = parameters.get("password");
-        this.name = parameters.get("name");
-        this.email = parameters.get("email");
-    }
-
-    public static User of(String input) {
-        Map<String, String> parameters = KeyValueTokenizer.of(input);
-        return new User(parameters);
+    public User(Map<String, String> params) {
+        this(params.get("userId"), params.get("password"), params.get("name"), params.get("email"));
     }
 
     public boolean validatePassword(String password) {

--- a/src/main/java/utils/KeyValueTokenizer.java
+++ b/src/main/java/utils/KeyValueTokenizer.java
@@ -2,19 +2,37 @@ package utils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.StringTokenizer;
 
 public class KeyValueTokenizer {
 
-    public static final String DELIM = "=&";
+    public static final String DELIM_AMPERSAND = "&";
+    public static final String DELIM_EQUAL = "=";
 
     public static Map<String, String> of(String input) {
         Map<String, String> parameters = new HashMap<>();
-        StringTokenizer stk = new StringTokenizer(input, DELIM);
-        while (stk.hasMoreTokens()) {
-            parameters.put(stk.nextToken(), stk.nextToken());
+        String[] tokens = input.split(DELIM_AMPERSAND);
+        for (String token : tokens) {
+            Pair pair = Pair.from(token);
+            parameters.put(pair.key, pair.value);
         }
         return parameters;
     }
 
+    private static class Pair {
+        private final String key;
+        private final String value;
+
+        private Pair(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public static Pair from(String rawString) {
+            String[] split = rawString.split(DELIM_EQUAL);
+            String key = split[0];
+            String value = "";
+            if (split.length > 1) value = split[1];
+            return new Pair(key, value);
+        }
+    }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,7 +24,7 @@ public class RequestHandler implements Runnable {
 
         controllers.put("/user/create", new CreateUserController(memberService));
         controllers.put("/user/login", new LoginController(memberService));
-        controllers.put("/user/list", new ListUserController());
+        controllers.put("/user/list.html", new ListUserController());
         controllers.put("/main", new MainController());
     }
 
@@ -47,7 +47,7 @@ public class RequestHandler implements Runnable {
             controller.service(httpRequest, httpResponse);
 
         } catch (Exception e) {
-            logger.error(e.getMessage());
+            logger.error(e.getMessage(), e);
         }
     }
 }

--- a/src/test/java/domain/HttpRequestTest.java
+++ b/src/test/java/domain/HttpRequestTest.java
@@ -31,7 +31,7 @@ public class HttpRequestTest {
 
         assertEquals(HttpMethod.POST, request.getMethod());
         assertEquals("/user/create", request.getUrl());
-        assertEquals("keep-alive", request.getHeader("Connection"));
+        assertEquals("keep-alive", request.getHeader("Connection").get(0));
         assertEquals("javajigi", request.getParameter("userId"));
     }
 }

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -3,8 +3,6 @@ package model;
 import domain.HttpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -15,26 +13,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
 
-    private Logger logger = LoggerFactory.getLogger(UserTest.class.getName());
-
     @Test
     @DisplayName("유저를 올바르게 생성")
-    void create_user() {
+    void create_user() throws IOException {
         String input = "GET /user/create?userId=javajigi&password=password&name=자바지기&email=javajigi%40slipp.net HTTP/1.1\n" +
                 "Host: localhost:8080\n" +
                 "Connection: keep-alive\n" +
                 "Accept: *\n";
 
         InputStream stream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
-        try {
-            HttpRequest httpRequest = HttpRequest.from(stream);
-            User user = new User(httpRequest.getParameters());
-            assertThat(user.getUserId()).isEqualTo("javajigi");
-            assertThat(user.getPassword()).isEqualTo("password");
-            assertThat(user.getName()).isEqualTo("자바지기");
-            assertThat(user.getEmail()).isEqualTo("javajigi%40slipp.net");
-        } catch (IOException e) {
-            logger.info(e.getMessage());
-        }
+
+        HttpRequest httpRequest = HttpRequest.from(stream);
+        User user = new User(httpRequest.getParameters());
+        assertThat(user.getUserId()).isEqualTo("javajigi");
+        assertThat(user.getPassword()).isEqualTo("password");
+        assertThat(user.getName()).isEqualTo("자바지기");
+        assertThat(user.getEmail()).isEqualTo("javajigi%40slipp.net");
     }
 }

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -3,6 +3,8 @@ package model;
 import domain.HttpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -12,6 +14,8 @@ import java.nio.charset.StandardCharsets;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
+
+    private Logger logger = LoggerFactory.getLogger(UserTest.class.getName());
 
     @Test
     @DisplayName("유저를 올바르게 생성")
@@ -30,7 +34,7 @@ class UserTest {
             assertThat(user.getName()).isEqualTo("자바지기");
             assertThat(user.getEmail()).isEqualTo("javajigi%40slipp.net");
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.info(e.getMessage());
         }
     }
 }


### PR DESCRIPTION
안녕하세요! 지난 리뷰를 반영한 PR입니다. kit의 리뷰 기회는 놓칠 수 없습니다.. ✍️🔥

앞서 짚어주신 코멘트에 대한 고민을 담아보았습니다.

1. *쿠키 헤더에는 여러 정보가 담길 수 있다. 이를 고려해보는 것이 좋겠다.*
링크 주신 rfc 문서를 통해 기존 `Map<String, String>` 구조를 `Map<String, List<String>>` 의 멀티밸류맵으로 변경했습니다. 쿠키만 따로 일급 컬렉션으로 만들지도 고민했지만, 다른 헤더도 단순 1:1 매핑을 했을때 문제가 생길 수 있다고 느껴서 헤더 전체를 변경하게 되었습니다.

2. *`/user/list.html` 에서 의도한 동작이 되지 않는다. ~~힌트: 응답헤더~~*
말씀해주신대로 응답 헤더 문제가 존재함을 확인했습니다. 로그인 쿠키가 false, true 둘 다 들어가서 결과적으로 로그인이 항상 실패하는 형태였어요. 결국에는 앞서 쿠키 헤더 관련 문제와도 엮여 있었습니다. 이 부분은 `logined=false` `logined=true`로 로그인 쿠키를 관리하는 기존 구조에 문제가 있다고 판단했습니다. `logined=false`라는 상태를 없애고, `logined=true`에 쿠키 유효시간을 추가하는 식으로 구현했습니다.

3. *패스워드나 아이디 하나만 채우면 이상하게 작동하는 문제는 토크나이저에 원인이 있다*
이 문제도 말씀해주신대로 `logger`를 사용해 찾았습니다. 입력하지 않으면 당연히 빈 문자열로 파싱될 것이라고 안일하게 생각했습니다 😭 이 부분은 키와 밸류 쌍을 표현하는 `Pair` 클래스를 도입해서 고쳐보았습니다.

4. *값이 없음을 No Key로 표현하는 것은 문제가 있다*
이것은 앞서 헤더의 밸류가 `List`로 바뀐 점과, 최근 읽은 이펙티브 자바의 *null 보다 빈 리스트를 반환하라*는 조언을 참고하여, 값이 없는 상황에서 `Collections.emptyList()`를 반환하도록 고쳤습니다.

<br>

의문점 : 
현재 `@`과 같은 특수기호가 `%40`으로 나타납니다. 확인해보니 이미 요청을 받아서 파라미터를 파싱하고 난 결과값부터 `%40`으로 나오더라구요. 아마 `HttpRequest.from()` 메서드에서 인풋스트림을 변환할 때 함께 바뀌는 것 같습니다.  UTF-8 인자를 빼도 동일한 증상이 나타나는데 원인이 궁금합니다.

<br>

매번 많이 배우고 있습니다. 감사합니다 😃